### PR TITLE
Clarify wording for units left

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -33,7 +33,7 @@ de:
       support_the_project: "Unterstützen Sie dieses Projekt"
       pledge: "Weiter"
       price: "Betrag :"
-      quantity: "Anzahl : %{quantity}"
+      quantity: "Anzahl übrig: %{quantity}"
   orders:
     new:
       confirmation: "Bestätigung"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
       support_the_project: "Support this project"
       pledge: "Pledge"
       price: "Price :"
-      quantity: "Quantity : %{quantity}"
+      quantity: "Quantity left: %{quantity}"
   orders:
     new:
       confirmation: "Confirmation"


### PR DESCRIPTION
Supporters were puzzled when seeing:

Anzahl: 7
Unterstützer: 7

And were thinking that the item is not available anymore.

For that reason I suggest to add "left / übrig" to the text