### PR TITLE
Correct campaign_body's h2 top/bottom margins

### DIFF
--- a/app/assets/stylesheets/campaigns.scss
+++ b/app/assets/stylesheets/campaigns.scss
@@ -38,8 +38,8 @@
   h2 {
     font-size: 1.75rem;
     color: #5B5A5A;
-    margin-bottom: 2em;
-    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+    margin-top: 2em;
     font-weight: 300;
   }
 


### PR DESCRIPTION
A minor change to make the campaign's header (h2) has more space on top, but less below.